### PR TITLE
Make device appearence use u16 instead of u32 as specified by the Blu…

### DIFF
--- a/bluer/src/device.rs
+++ b/bluer/src/device.rs
@@ -323,8 +323,8 @@ define_properties!(
 
         ///	External appearance of device, as found on GAP service.
         property(
-            Appearance, u32,
-            dbus: (INTERFACE, "Appearance", u32, OPTIONAL),
+            Appearance, u16,
+            dbus: (INTERFACE, "Appearance", u16, OPTIONAL),
             get: (appearance, v => {v.to_owned()}),
         );
 


### PR DESCRIPTION
Bluez DBUS Device API requires u16 for Appearence property: https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/doc/device-api.txt

The current implementation uses u32 and therefore fails with:
Error: Error { kind: Internal(DBus("org.freedesktop.DBus.Error.Failed")), message: "D-Bus argument type mismatch at position 0: expected Variant, found same but still different somehow" }
