### PR TITLE
Support for adding desired capability when registering agent

### DIFF
--- a/bluer-tools/src/gattcat.rs
+++ b/bluer-tools/src/gattcat.rs
@@ -293,7 +293,7 @@ async fn register_agent(session: &Session, request_default: bool, set_trust: boo
         authorize_service: Some(Box::new(|req| authorize_service(req).boxed())),
         ..Default::default()
     };
-    let handle = session.register_agent(agent).await?;
+    let handle = session.register_agent(agent, None).await?;
     Ok(handle)
 }
 

--- a/bluer-tools/src/rfcat.rs
+++ b/bluer-tools/src/rfcat.rs
@@ -102,7 +102,7 @@ impl ConnectOpts {
                 adapter.set_pairable(false).await?;
 
                 let agent = Agent::default();
-                let _agent_hndl = session.register_agent(agent).await?;
+                let _agent_hndl = session.register_agent(agent, None).await?;
 
                 let profile = Profile {
                     uuid,
@@ -237,7 +237,7 @@ impl ListenOpts {
                 adapter.set_pairable(false).await?;
 
                 let agent = Agent::default();
-                let _agent_hndl = session.register_agent(agent).await?;
+                let _agent_hndl = session.register_agent(agent, None).await?;
 
                 let profile = Profile {
                     uuid,
@@ -339,7 +339,7 @@ impl ServeOpts {
                 adapter.set_pairable(true).await?;
 
                 let agent = Agent::default();
-                _agent_hndl = session.register_agent(agent).await?;
+                _agent_hndl = session.register_agent(agent, None).await?;
 
                 let profile = Profile {
                     uuid,

--- a/bluer/src/agent.rs
+++ b/bluer/src/agent.rs
@@ -452,7 +452,9 @@ impl RegisteredAgent {
         })
     }
 
-    pub(crate) async fn register(self, inner: Arc<SessionInner>, capability: Option<&str>) -> Result<AgentHandle> {
+    pub(crate) async fn register(
+        self, inner: Arc<SessionInner>, capability: Option<&str>,
+    ) -> Result<AgentHandle> {
         let name = dbus::Path::new(format!("{}{}", AGENT_PREFIX, Uuid::new_v4().to_simple())).unwrap();
         let capability = match capability {
             Some(c) => c,

--- a/bluer/src/agent.rs
+++ b/bluer/src/agent.rs
@@ -452,9 +452,12 @@ impl RegisteredAgent {
         })
     }
 
-    pub(crate) async fn register(self, inner: Arc<SessionInner>) -> Result<AgentHandle> {
+    pub(crate) async fn register(self, inner: Arc<SessionInner>, capability: Option<&str>) -> Result<AgentHandle> {
         let name = dbus::Path::new(format!("{}{}", AGENT_PREFIX, Uuid::new_v4().to_simple())).unwrap();
-        let capability = self.a.capability();
+        let capability = match capability {
+            Some(c) => c,
+            None => self.a.capability(),
+        };
         let request_default = self.a.request_default;
         log::trace!("Publishing agent at {} with capability {}", &name, &capability);
 

--- a/bluer/src/session.rs
+++ b/bluer/src/session.rs
@@ -223,9 +223,9 @@ impl Session {
     /// agents per application is not supported.
     ///
     /// Drop the returned [AgentHandle] to unregister the agent.
-    pub async fn register_agent(&self, agent: Agent) -> Result<AgentHandle> {
+    pub async fn register_agent(&self, agent: Agent, capability: Option<&str>) -> Result<AgentHandle> {
         let reg_agent = RegisteredAgent::new(agent);
-        reg_agent.register(self.inner.clone()).await
+        reg_agent.register(self.inner.clone(), capability).await
     }
 
     /// This registers a [Bluetooth profile implementation](Profile) for RFCOMM connections.


### PR DESCRIPTION
This pull request adds support to specify desired capability when registering agent through `session.register_agent(agent, "KeyboardOnly");`

Similar to how it is done here: https://github.com/bluez/bluez/blob/3f03ea4aebcee5166cd057047b5eb511eda90f42/test/simple-agent#L161
`manager.RegisterAgent(path, capability);`
