### PR TITLE
Make DescriptorReadRequest offset property optional

### DIFF
--- a/bluer/src/gatt/local.rs
+++ b/bluer/src/gatt/local.rs
@@ -1053,7 +1053,7 @@ pub struct DescriptorReadRequest {
 impl DescriptorReadRequest {
     fn from_dict(dict: &PropMap) -> DbusResult<Self> {
         Ok(Self {
-            offset: read_prop!(dict, "offset", u16),
+            offset: read_opt_prop!(dict, "offset", u16).unwrap_or_default(),
             link: read_opt_prop!(dict, "link", String).and_then(|v| v.parse().ok()),
         })
     }
@@ -1074,7 +1074,7 @@ pub struct DescriptorWriteRequest {
 impl DescriptorWriteRequest {
     fn from_dict(dict: &PropMap) -> DbusResult<Self> {
         Ok(Self {
-            offset: read_prop!(dict, "offset", u16),
+            offset: read_opt_prop!(dict, "offset", u16).unwrap_or_default(),
             link: read_opt_prop!(dict, "link", String).and_then(|v| v.parse().ok()),
             prepare_authorize: read_prop!(dict, "prepare_authorize", bool),
         })


### PR DESCRIPTION
The [offset property](https://github.com/bluez/bluez/blob/7d0fc7e7f0e4585a97c6a214872106507d1199b9/doc/gatt-api.txt#L318) is often not specified in descriptor `ReadValue` calls, which leads to the following error:

```
[2022-01-07T15:47:37Z TRACE bluer] ... org.bluez.GattDescriptor1.ReadValue (...) -> Err(MethodErr(ErrorName("org.freedesktop.DBus.Error.InvalidArgs\u{0}"), "Invalid argument \"offset\""))
```

This PR makes that property optional.