### PR TITLE
Limit nix features

### DIFF
--- a/bluer/Cargo.toml
+++ b/bluer/Cargo.toml
@@ -59,7 +59,7 @@ strum = { version = "0.24", features = ["derive"] }
 num-traits = "0.2"
 num-derive = "0.3"
 libc = "0.2"
-nix = "0.24"
+nix = { version = "0.24", default-features = false, features = ["ioctl"] }
 custom_debug = { version = "0.5", optional = true }
 displaydoc = { version = "0.2", optional = true }
 log = "0.4"


### PR DESCRIPTION
This removes memoffset as an indirect dependency, and should slightly reduce build times.