### PR TITLE
Fix D-Bus AuthorizeService method name

### DIFF
--- a/bluer/src/agent.rs
+++ b/bluer/src/agent.rs
@@ -428,7 +428,7 @@ impl RegisteredAgent {
                 },
             );
             ib.method_with_cr_async(
-                "RequestConfirmation",
+                "AuthorizeService",
                 ("device", "uuid"),
                 (),
                 |ctx, cr, (device, uuid): (dbus::Path<'static>, String)| {


### PR DESCRIPTION
Fixes a typo for the `AuthorizeService` D-Bus agent method that caused `bluetoothd` to error with
```log
= bluetoothd: profiles/input/server.c:auth_callback() Access denied: Unknown method AuthorizeService
```

All the other method signatures [look correct](https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/doc/agent-api.txt).