### PR TITLE
Use nix::ioctl_num_type and libc::Ioctl to have the correct type on musl

### DIFF
--- a/bluer/src/sock.rs
+++ b/bluer/src/sock.rs
@@ -1,6 +1,6 @@
 //! System socket base.
 
-use libc::{c_int, c_ulong, sockaddr, socklen_t, SOCK_CLOEXEC, SOCK_NONBLOCK};
+use libc::{c_int, sockaddr, socklen_t, Ioctl, SOCK_CLOEXEC, SOCK_NONBLOCK};
 use std::{
     io::{Error, ErrorKind, Result},
     mem::{size_of, MaybeUninit},
@@ -298,7 +298,7 @@ pub fn setsockopt<T>(socket: &OwnedFd, level: c_int, optname: i32, optval: &T) -
 }
 
 /// Perform an IOCTL that reads a single value.
-pub fn ioctl_read<T>(socket: &OwnedFd, request: c_ulong) -> Result<T> {
+pub fn ioctl_read<T>(socket: &OwnedFd, request: Ioctl) -> Result<T> {
     let mut value: MaybeUninit<T> = MaybeUninit::uninit();
     let ret = unsafe { libc::ioctl(socket.as_raw_fd(), request, value.as_mut_ptr()) };
     if ret == -1 {
@@ -310,7 +310,7 @@ pub fn ioctl_read<T>(socket: &OwnedFd, request: c_ulong) -> Result<T> {
 
 /// Perform an IOCTL that writes a single value.
 #[allow(dead_code)]
-pub fn ioctl_write<T>(socket: &OwnedFd, request: c_ulong, value: &T) -> Result<c_int> {
+pub fn ioctl_write<T>(socket: &OwnedFd, request: Ioctl, value: &T) -> Result<c_int> {
     let ret = unsafe { libc::ioctl(socket.as_raw_fd(), request, value as *const _) };
     if ret == -1 {
         return Err(Error::last_os_error());

--- a/bluer/src/sys.rs
+++ b/bluer/src/sys.rs
@@ -1,8 +1,8 @@
 //! System native types and constants.
 #![allow(dead_code)]
 
-use libc::{c_int, c_ulong, c_ushort, sa_family_t};
-use nix::request_code_write;
+use libc::{c_int, c_ushort, sa_family_t};
+use nix::{request_code_write, sys::ioctl::ioctl_num_type};
 use std::mem::size_of;
 
 pub const SOL_L2CAP: i32 = 6;
@@ -185,8 +185,8 @@ pub struct rfcomm_conninfo {
 pub const RFCOMM_REUSE_DLC: u32 = 1 << 0;
 pub const RFCOMM_RELEASE_ONHUP: u32 = 1 << 1;
 
-pub const RFCOMMCREATEDEV: c_ulong = request_code_write!('R', 200, size_of::<c_int>());
-pub const RFCOMMRELEASEDEV: c_ulong = request_code_write!('R', 201, size_of::<c_int>());
+pub const RFCOMMCREATEDEV: ioctl_num_type = request_code_write!('R', 200, size_of::<c_int>());
+pub const RFCOMMRELEASEDEV: ioctl_num_type = request_code_write!('R', 201, size_of::<c_int>());
 
 /// RFCOMM TTY device request.
 #[repr(C)]


### PR DESCRIPTION
musl uses i32 instead of u64.
