### PR TITLE
Fix AdvertisingData handling

### DIFF
--- a/bluer/src/device.rs
+++ b/bluer/src/device.rs
@@ -507,8 +507,16 @@ define_properties!(
         /// application are exposed.
         property(
             AdvertisingData, HashMap<u8, Vec<u8>>,
-            dbus: (INTERFACE, "AdvertisingData", HashMap<u8, Vec<u8>>, OPTIONAL),
-            get: (advertising_data, v => {v.to_owned()}),
+            dbus: (INTERFACE, "AdvertisingData", HashMap<u8, Variant<Box<dyn RefArg  + 'static>>>, OPTIONAL),
+            get: (advertising_data, m => {
+                let mut mt: HashMap<u8, Vec<u8>> = HashMap::new();
+                for (k, v) in m {
+                    if let Some(v) = dbus::arg::cast(&v.0).cloned() {
+                        mt.insert(*k, v);
+                    }
+                }
+                mt
+            }),
         );
     }
 );


### PR DESCRIPTION
which has basically the same DBus message structure as ManufacturerData.

With below modification to `bluer/examples/discover_devices.rs`:
```diff
diff --git a/bluer/examples/discover_devices.rs b/bluer/examples/discover_devices.rs
index 1a52b9c..a66cf48 100644
--- a/bluer/examples/discover_devices.rs
+++ b/bluer/examples/discover_devices.rs
@@ -4,6 +4,10 @@ use bluer::{Adapter, AdapterEvent, Address, DeviceEvent};
 use futures::{pin_mut, stream::SelectAll, StreamExt};
 use std::{collections::HashSet, env};
 
+fn dump_vecu8(vec: &[u8], sep: char) {
+    ...
+}
+
 async fn query_device(adapter: &Adapter, addr: Address) -> bluer::Result<()> {
     let device = adapter.device(addr)?;
     println!("    Address type:       {}", device.address_type().await?);
@@ -18,6 +22,15 @@ async fn query_device(adapter: &Adapter, addr: Address) -> bluer::Result<()> {
     println!("    RSSI:               {:?}", device.rssi().await?);
     println!("    TX power:           {:?}", device.tx_power().await?);
     println!("    Manufacturer data:  {:?}", device.manufacturer_data().await?);
+    let adv = device.advertising_data().await?;
+    if adv.is_some() {
+        let adv = adv.unwrap();
+        for (adv_key, adv_dat) in &adv {
+            print!("    AdvertisingData:    {} -> ", adv_key);
+            dump_vecu8(&adv_dat, ' ');
+            println!();
+        }
+    }
     println!("    Service data:       {:?}", device.service_data().await?);
     Ok(())
 }
```
We can dump raw AdvertisingData:
```
Device added: 70:1D:A6:FB:67:62
    Address type:       random
    Name:               None
    Icon:               None
    Class:              None
    UUIDs:              {}
    Paired:             false
    Connected:          false
    Trusted:            false
    Modalias:           None
    RSSI:               Some(-96)
    TX power:           Some(12)
    Manufacturer data:  Some({76: [16, 5, 83, 28, 219, 63, 138]})
    AdvertisingData:    38 -> 02 01 1a 02 0a 0c 0a ff 4c 00 10 05 53 1c db 3f 8a 
    Service data:       None

Device added: 40:ED:26:FD:48:AE
    Address type:       random
    Name:               None
    Icon:               None
    Class:              None
    UUIDs:              {}
    Paired:             false
    Connected:          false
    Trusted:            false
    Modalias:           None
    RSSI:               Some(-96)
    TX power:           Some(7)
    Manufacturer data:  Some({76: [16, 5, 33, 24, 249, 83, 101]})
    AdvertisingData:    38 -> 02 01 1a 02 0a 07 0a ff 4c 00 10 05 21 18 f9 53 65 
    Service data:       None
```