### PR TITLE
Apply `#[serde(default)]` to Advertisement struct 

### DIFF
--- a/bluer/src/adv.rs
+++ b/bluer/src/adv.rs
@@ -131,6 +131,7 @@ impl Capabilities {
 /// Use [Adapter::advertise] to register a new advertisement.
 #[derive(Clone, Debug, Default, Eq, PartialEq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(default))]
 pub struct Advertisement {
     /// Determines the type of advertising packet requested.
     pub advertisement_type: Type,

--- a/bluer/src/adv.rs
+++ b/bluer/src/adv.rs
@@ -160,7 +160,7 @@ pub struct Advertisement {
     ///
     /// Note: Types already handled by other properties shall
     /// not be used.
-    pub advertisting_data: BTreeMap<u8, Vec<u8>>,
+    pub advertising_data: BTreeMap<u8, Vec<u8>>,
     /// Advertise as general discoverable.
     ///
     /// When present this
@@ -255,7 +255,7 @@ impl Advertisement {
                 Some(la.service_data.iter().map(|(k, v)| (k.to_string(), Variant(v.clone()))).collect::<HashMap<_, _>>())
             });
             cr_property!(ib, "Data", la => {
-                Some(la.advertisting_data.iter().map(|(k, v)| (*k, Variant(v.clone()))).collect::<HashMap<_, _>>())
+                Some(la.advertising_data.iter().map(|(k, v)| (*k, Variant(v.clone()))).collect::<HashMap<_, _>>())
             });
             cr_property!(ib, "Discoverable", la => {
                 la.discoverable


### PR DESCRIPTION
Use default values for missing fields when deserializing the Advertisement struct. This allows for omitting entries like `manufacturer_data: {}` and `_non_exhaustive: null` in the JSON.

Also fixes a typo with the `Advertisement::advertising_data` field.

Ref: https://serde.rs/container-attrs.html#default