### PR TITLE
bluer::monitor::MonitorManager#register deadlock

### DIFF
--- a/bluer/src/monitor.rs
+++ b/bluer/src/monitor.rs
@@ -438,8 +438,10 @@ impl MonitorManager {
             event_tx: Mutex::new(Some(event_tx)),
         };
 
-        let mut cr = self.inner.crossroads.lock().await;
-        cr.insert(name.clone(), [&self.inner.monitor_token], Arc::new(reg));
+        {
+            let mut cr = self.inner.crossroads.lock().await;
+            cr.insert(name.clone(), [&self.inner.monitor_token], Arc::new(reg));
+        }
 
         let inner = self.inner.clone();
         let unreg_name = name.clone();


### PR DESCRIPTION
As far as I can tell, bluer::monitor::MonitorManager#register seems to deadlock, narrowing the life of the MutexGuard seems to avoid this, I suspect this is an interaction between the tokio crossroads [message processing task](https://github.com/bluez/bluer/blob/master/bluer/src/session.rs#L266-L267) spawned by session and MonitorManager#register holding the lock and waiting for an Activate message or a failure.



