### PR TITLE
fixes typo in l2cap_client.rs

### DIFF
--- a/bluer/examples/l2cap_client.rs
+++ b/bluer/examples/l2cap_client.rs
@@ -19,7 +19,7 @@ async fn main() -> bluer::Result<()> {
 
     let args: Vec<_> = env::args().collect();
     if args.len() != 2 {
-        eprintln!("Specify target Bluetooth address as argment");
+        eprintln!("Specify target Bluetooth address as argument");
         exit(1);
     }
 


### PR DESCRIPTION
Fixes a typo: "argment" -> "argument" in the l2cap_client.rs