### PR TITLE
GATT: UnixStream -> UnixDatagram

### DIFF
--- a/bluer/src/gatt/local.rs
+++ b/bluer/src/gatt/local.rs
@@ -618,9 +618,9 @@ impl CharacteristicWriteIoRequest {
     /// Accept the write request.
     pub fn accept(self) -> Result<CharacteristicReader> {
         let CharacteristicWriteIoRequest { adapter_name, device_address, mtu, tx, .. } = self;
-        let (fd, stream) = make_socket_pair(false)?;
+        let (fd, socket) = make_socket_pair(false)?;
         let _ = tx.send(Ok(fd));
-        Ok(CharacteristicReader { adapter_name, device_address, mtu: mtu.into(), stream, buf: Vec::new() })
+        Ok(CharacteristicReader { adapter_name, device_address, mtu: mtu.into(), socket, buf: Vec::new() })
     }
 
     /// Reject the write request.
@@ -941,13 +941,13 @@ impl RegisteredCharacteristic {
                             Some(CharacteristicNotify { method: CharacteristicNotifyMethod::Io, .. }) => {
                                 // BlueZ has already confirmed the start of the notification session.
                                 // So there is no point in making this fail-able by our users.
-                                let (fd, stream) = make_socket_pair(true).map_err(|_| ReqError::Failed)?;
+                                let (fd, socket) = make_socket_pair(true).map_err(|_| ReqError::Failed)?;
                                 let mtu = mtu_workaround(options.mtu.into());
                                 let writer = CharacteristicWriter {
                                     adapter_name: options.adapter_name.clone(),
                                     device_address: options.device_address,
                                     mtu,
-                                    stream,
+                                    socket,
                                 };
                                 let _ = reg
                                     .c

--- a/bluer/src/gatt/mod.rs
+++ b/bluer/src/gatt/mod.rs
@@ -315,12 +315,10 @@ impl AsyncWrite for CharacteristicWriter {
 
     fn poll_flush(self: Pin<&mut Self>, _cx: &mut std::task::Context) -> Poll<std::io::Result<()>> {
         Poll::Ready(Ok(()))
-        // self.project().stream.poll(cx)
     }
 
     fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut std::task::Context) -> Poll<std::io::Result<()>> {
         Poll::Ready(Ok(()))
-        // self.project().stream.poll_shutdown(cx)
     }
 }
 

--- a/bluer/src/gatt/remote.rs
+++ b/bluer/src/gatt/remote.rs
@@ -7,7 +7,7 @@ use dbus::{
 };
 use futures::{Stream, StreamExt};
 use std::{fmt, os::unix::prelude::FromRawFd, sync::Arc};
-use tokio::net::UnixStream;
+use tokio::net::UnixDatagram;
 use uuid::Uuid;
 
 use super::{
@@ -351,9 +351,9 @@ impl Characteristic {
     pub async fn write_io(&self) -> Result<CharacteristicWriter> {
         let options = PropMap::new();
         let (fd, mtu): (OwnedFd, u16) = self.call_method("AcquireWrite", (options,)).await?;
-        let stream = unsafe { std::os::unix::net::UnixStream::from_raw_fd(fd.into_fd()) };
+        let stream = unsafe { std::os::unix::net::UnixDatagram::from_raw_fd(fd.into_fd()) };
         stream.set_nonblocking(true)?;
-        let stream = UnixStream::from_std(stream)?;
+        let stream = UnixDatagram::from_std(stream)?;
         let mtu = mtu_workaround(mtu.into());
         Ok(CharacteristicWriter {
             adapter_name: self.adapter_name().to_string(),
@@ -431,9 +431,9 @@ impl Characteristic {
     pub async fn notify_io(&self) -> Result<CharacteristicReader> {
         let options = PropMap::new();
         let (fd, mtu): (OwnedFd, u16) = self.call_method("AcquireNotify", (options,)).await?;
-        let stream = unsafe { std::os::unix::net::UnixStream::from_raw_fd(fd.into_fd()) };
+        let stream = unsafe { std::os::unix::net::UnixDatagram::from_raw_fd(fd.into_fd()) };
         stream.set_nonblocking(true)?;
-        let stream = UnixStream::from_std(stream)?;
+        let stream = UnixDatagram::from_std(stream)?;
         Ok(CharacteristicReader {
             adapter_name: self.adapter_name().to_string(),
             device_address: self.device_address,

--- a/bluer/src/gatt/remote.rs
+++ b/bluer/src/gatt/remote.rs
@@ -351,15 +351,15 @@ impl Characteristic {
     pub async fn write_io(&self) -> Result<CharacteristicWriter> {
         let options = PropMap::new();
         let (fd, mtu): (OwnedFd, u16) = self.call_method("AcquireWrite", (options,)).await?;
-        let stream = unsafe { std::os::unix::net::UnixDatagram::from_raw_fd(fd.into_fd()) };
-        stream.set_nonblocking(true)?;
-        let stream = UnixDatagram::from_std(stream)?;
+        let socket = unsafe { std::os::unix::net::UnixDatagram::from_raw_fd(fd.into_fd()) };
+        socket.set_nonblocking(true)?;
+        let socket = UnixDatagram::from_std(socket)?;
         let mtu = mtu_workaround(mtu.into());
         Ok(CharacteristicWriter {
             adapter_name: self.adapter_name().to_string(),
             device_address: self.device_address,
             mtu,
-            stream,
+            socket,
         })
     }
 
@@ -431,14 +431,14 @@ impl Characteristic {
     pub async fn notify_io(&self) -> Result<CharacteristicReader> {
         let options = PropMap::new();
         let (fd, mtu): (OwnedFd, u16) = self.call_method("AcquireNotify", (options,)).await?;
-        let stream = unsafe { std::os::unix::net::UnixDatagram::from_raw_fd(fd.into_fd()) };
-        stream.set_nonblocking(true)?;
-        let stream = UnixDatagram::from_std(stream)?;
+        let socket = unsafe { std::os::unix::net::UnixDatagram::from_raw_fd(fd.into_fd()) };
+        socket.set_nonblocking(true)?;
+        let socket = UnixDatagram::from_std(socket)?;
         Ok(CharacteristicReader {
             adapter_name: self.adapter_name().to_string(),
             device_address: self.device_address,
             mtu: mtu.into(),
-            stream,
+            socket,
             buf: Vec::new(),
         })
     }


### PR DESCRIPTION
GATT communication with bluetoothd happens over a `SOCK_SEQPACKET` socket, however bluer uses `UnixStream` socket for those sockets, this leads to issues with tokio/mio/epoll, when receiving notification data from from a remote GATT characteristic. The problem works as follows:
- the bluer application does initialization and subscribes to GATT notification events, tokio/mio puts the `UnixStream` socket into epoll using edge trigger mode.
- Remote service send multiple notification event(at least 3?)
- The bluer application wakes from epoll and receives the first event, it then begins processing the first event.
- While the application processes the event, more events are received(at least 2 more)
- The application finishes processing of the event and call `epoll_wait`, as there has been more new events since last epoll the application is woken immediately to process the second event.
- When the process enter `epoll_wait` this time it will not get woken again, even if there are still events to process, as there are no NEW events since last epoll. The application will only receive the next event when an additional new event is received, however this new event will remain in the queue and not be processed.

This happens because tokio/mio assumes that on a `UnixStream` socket there is no more data available if the read does not fill the whole buffer. However the correct thing to do on a `SOCK_SEQPACKET` socket is to read from the socket until it returns EAGAIN processing every packet in the queue.

This is what `UnixDatagram` socket does.

This pull request uses `UnixDatagram` sockets instead of `UnixStream` sockets for GATT Characteristic communication.