### PR TITLE
agent: fix NoInputNoOutput agents rejecting all pairing requests

### DIFF
--- a/bluer/src/agent.rs
+++ b/bluer/src/agent.rs
@@ -164,9 +164,15 @@ pub type AuthorizeServiceFn =
 /// Bluetooth authorization agent handler.
 ///
 /// Each handler that is set to [None] will reject the request.
-/// The capabilities of the agent are published accordingly.
-/// Setting all handlers to [None] (the default) will result in a `NoInputNoOutput` handler
-/// that accepts all requests.
+/// The capabilities of the agent are published according to the
+/// input and output handlers that are set.
+/// The [request_authorization](Self::request_authorization) and
+/// [authorize_service](Self::authorize_service) handlers represent local
+/// authorization policy and thus do not affect the published capabilities.
+///
+/// Setting all handlers to [None] (the default) will result in a `NoInputNoOutput` agent
+/// that accepts all incoming pairing attempts using the just-works model
+/// and all service authorization requests.
 ///
 /// The future of a particular request is dropped when BlueZ cancels that request.
 ///
@@ -256,12 +262,14 @@ pub struct Agent {
 
 impl Agent {
     /// BlueZ capability parameter.
+    ///
+    /// The `request_authorization` and `authorize_service` handlers are not
+    /// considered, since they represent local authorization policy and are
+    /// called by BlueZ regardless of the published capabilities.
     pub(crate) fn capability(&self) -> &'static str {
         let keyboard = self.request_passkey.is_some() || self.request_pin_code.is_some();
         let display_only = self.display_passkey.is_some() || self.display_pin_code.is_some();
-        let yes_no = self.request_confirmation.is_some()
-            || self.request_authorization.is_some()
-            || self.authorize_service.is_some();
+        let yes_no = self.request_confirmation.is_some();
 
         match (keyboard, display_only, yes_no) {
             (true, false, false) => "KeyboardOnly",
@@ -271,6 +279,17 @@ impl Agent {
             (false, false, false) => "NoInputNoOutput",
         }
     }
+
+    /// Whether no handlers are set.
+    fn is_empty(&self) -> bool {
+        self.request_pin_code.is_none()
+            && self.display_pin_code.is_none()
+            && self.request_passkey.is_none()
+            && self.display_passkey.is_none()
+            && self.request_confirmation.is_none()
+            && self.request_authorization.is_none()
+            && self.authorize_service.is_none()
+    }
 }
 
 pub(crate) struct RegisteredAgent {
@@ -279,7 +298,14 @@ pub(crate) struct RegisteredAgent {
 }
 
 impl RegisteredAgent {
-    pub(crate) fn new(agent: Agent) -> Self {
+    pub(crate) fn new(mut agent: Agent) -> Self {
+        // An agent without any handlers acts as a NoInputNoOutput agent that
+        // accepts all requests it can receive, i.e. authorization of incoming
+        // just-works pairing attempts and service connections.
+        if agent.is_empty() {
+            agent.request_authorization = Some(Box::new(|_| Box::pin(async { Ok(()) })));
+            agent.authorize_service = Some(Box::new(|_| Box::pin(async { Ok(()) })));
+        }
         Self { a: agent, cancel: Mutex::new(None) }
     }
 


### PR DESCRIPTION
## Problem

It is currently impossible to register a working `NoInputNoOutput` agent, because the capability string passed to `RegisterAgent` is derived automatically from which handler fields are set:

- **All handlers `None`** → capability is `NoInputNoOutput`, but BlueZ still calls `RequestAuthorization` for incoming just-works pairing (and `AuthorizeService` for service connections). Since the handler is `None`, bluer replies with `org.bluez.Error.Rejected` — so **every pairing attempt fails**.
- **Setting `request_authorization` to accept** → the derivation flips the capability to `DisplayYesNo`, so MITM-capable centrals (iOS in particular sets the MITM flag) negotiate numeric comparison instead of just-works. The phone then shows a "confirm this code" dialog for a code that a headless device cannot display anywhere.

This also contradicts the existing `Agent` documentation, which states:

> Setting all handlers to [None] (the default) will result in a `NoInputNoOutput` handler that accepts all requests.

The all-`None` agent rejected all requests instead, so the documented behavior never worked.

## Use case

A headless device (no display, no input) exposing a GATT service with `encrypt-read`/`encrypt-write` characteristics. Phones must be able to pair via just-works with a single consent tap and no passkey dialog. This requires advertising `NoInputNoOutput` *and* accepting `RequestAuthorization`/`AuthorizeService`.

## Fix

1. **Exclude `request_authorization` and `authorize_service` from the capability derivation.** Per the BlueZ agent API, `RequestAuthorization` is called "to request the user to authorize an incoming pairing attempt which would in other circumstances trigger the just-works model" — it is a local authorization policy decision, invoked regardless of the published capability, not an input/output capability. The same applies to `AuthorizeService`. Only `request_confirmation` now implies yes/no capability. With this change, an agent with only authorization handlers correctly advertises `NoInputNoOutput`.

2. **Make the all-`None` default match the documented behavior.** When no handlers are set, default `RequestAuthorization` and `AuthorizeService` handlers that accept all requests are installed at registration, so the default `Agent` is the documented "`NoInputNoOutput` handler that accepts all requests". Code-input requests (`RequestPinCode`, `RequestPasskey`, etc.) still reject — BlueZ does not send them to a `NoInputNoOutput` agent.

## Behavior changes

- An agent with only `request_authorization`/`authorize_service` set now publishes `NoInputNoOutput` instead of `DisplayYesNo`. Such configurations were effectively broken before, since they had no `request_confirmation` to satisfy numeric comparison.
- An all-`None` agent now accepts incoming just-works pairing instead of rejecting it, matching the existing documentation.

`cargo build` and `cargo clippy --all-features` pass with no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code) -  I (a Human) did manually verify the issue and audit the code. 