### PR TITLE
rfcomm: emit Channel=0 for a Server profile with no channel

### DIFF
--- a/bluer/src/rfcomm/profile.rs
+++ b/bluer/src/rfcomm/profile.rs
@@ -150,8 +150,9 @@ impl Profile {
         if let Some(role) = &self.role {
             pm.insert("Role".to_string(), Variant(role.to_string().box_clone()));
         }
-        if let Some(channel) = &self.channel {
-            pm.insert("Channel".to_string(), Variant(channel.box_clone()));
+        if self.channel.is_some() || matches!(&self.role, Some(Role::Server)) {
+            // If role is server and channel is None, we actually should send 0, meaning auto-assign.
+            pm.insert("Channel".to_string(), Variant(self.channel.unwrap_or_default().box_clone()));
         }
         if let Some(psm) = &self.psm {
             pm.insert("PSM".to_string(), Variant(psm.box_clone()));


### PR DESCRIPTION
When rfcomm Profile role is Server, currently bluer omits channel from the dbus dict, which downstream in bluez results in no rfcomm socket being created, and channel attr ommitted from the sdp record.

This changes it to send channel: 0 instead, which is interpreted as auto, which is what we want.

This now behaves correctly in my usage.